### PR TITLE
Fix LibJS installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ installing engines to make eshost automatically find the installed engines.
 | [GraalJS][]        | `graaljs`                        | ✅           | ✅             |              | ✅          | ✅            |              | ✅          |
 | [Hermes][]         | `hermes`                         | ✅           |                |              |             |               |              | ✅          |
 | [Kiesel][]         | `kiesel`                         | ✅           | ✅             | ✅           | ✅          | ✅            | ✅           | ✅          |
-| [LibJS][]          | `serenity-js`                    | ✅           | ✅             |              | ✅          |               |              |             |
+| [LibJS][]          | `ladybird-js`                    | ✅           | ✅             |              | ✅          |               |              |             |
 | [JavaScriptCore][] | `jsc`, `javascriptcore`          | ✅           | ✅             |              | ✅          |               |              | ✅          |
 | [QuickJS][]        | `quickjs`, `quickjs-run-test262` | ✅           |                | ✅           | ✅          |               | ✅           | ✅          |
 | [SpiderMonkey][]   | `sm`, `spidermonkey`             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |
@@ -57,7 +57,7 @@ Some binaries may be exposed as batch/shell scripts to properly handling shared 
 [GraalJS]: https://github.com/graalvm/graaljs
 [Hermes]: https://hermesengine.dev
 [Kiesel]: https://kiesel.dev
-[LibJS]: https://github.com/serenityos/serenity
+[LibJS]: https://github.com/LadybirdBrowser/ladybird
 [JavaScriptCore]: https://developer.apple.com/documentation/javascriptcore
 [QuickJS]: https://bellard.org/quickjs/
 [SpiderMonkey]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey

--- a/src/engines/libjs.js
+++ b/src/engines/libjs.js
@@ -60,9 +60,8 @@ class LibJSInstaller extends Installer {
   }
 
   async install() {
-    await this.registerAssets('lib/**');
     const js = await this.registerAsset('bin/js');
-    this.binPath = await this.registerScript('serenity-js', `"${js}"`);
+    this.binPath = await this.registerScript('ladybird-js', `"${js}"`);
   }
 
   async test() {


### PR DESCRIPTION
It's a static build as of https://github.com/LadybirdBrowser/ladybird/pull/2225.

```
esvu ✖ Error: No files matched lib/**
    at LibJSInstaller.registerAssets (/usr/local/lib/node_modules/esvu/src/installer.js:182:13)
    at async LibJSInstaller.install (/usr/local/lib/node_modules/esvu/src/engines/libjs.js:65:5)
    at async LibJSInstaller.install (/usr/local/lib/node_modules/esvu/src/installer.js:107:5)
    at async installEngine (/usr/local/lib/node_modules/esvu/src/bin.js:121:3)
    at async main (/usr/local/lib/node_modules/esvu/src/bin.js:168:7)
```

Also renamed the name while we're here, this is _not_ Serenity's LibJS.