### PR TITLE
Only use GitHub token when provided

### DIFF
--- a/src/engines/graaljs.js
+++ b/src/engines/graaljs.js
@@ -72,7 +72,8 @@ class GraalJSInstaller extends Installer {
 
   static async resolveVersion(version) {
     if (version === 'latest') {
-      const body = await fetch('https://api.github.com/repos/oracle/graaljs/releases', { headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN } })
+      const headers = process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {};
+      const body = await fetch('https://api.github.com/repos/oracle/graaljs/releases', { headers })
         .then((r) => r.json());
       const versions = body
         .filter((b) => !b.prerelease)

--- a/src/engines/libjs.js
+++ b/src/engines/libjs.js
@@ -33,13 +33,14 @@ class LibJSInstaller extends Installer {
       throw new Error('LibJS only provides binary builds for \'latest\'');
     }
 
-    const artifact = await fetch('https://api.github.com/repos/ladybirdbrowser/ladybird/actions/artifacts', { headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN } })
+    const headers = process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {};
+    const artifact = await fetch('https://api.github.com/repos/ladybirdbrowser/ladybird/actions/artifacts', { headers })
       .then((x) => x.json())
       .then((x) => x.artifacts.find((a) => a.name === artifactName))
       .catch(() => {
         throw new Error(`Failed to find any artifacts for ${artifactName} on ladybirdbrowser/ladybird`);
       });
-    const run = await fetch('https://api.github.com/repos/ladybirdbrowser/ladybird/actions/runs?event=push&branch=master&status=success', { headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN } })
+    const run = await fetch('https://api.github.com/repos/ladybirdbrowser/ladybird/actions/runs?event=push&branch=master&status=success', { headers })
       .then((x) => x.json())
       .then((x) => x.workflow_runs.filter((a) => a.name === 'Package the js repl as a binary artifact'))
       .then((x) => x.sort((a, b) => a.check_suite_id > b.check_suite_id)[0])

--- a/src/engines/xs.js
+++ b/src/engines/xs.js
@@ -33,7 +33,8 @@ class XSInstaller extends Installer {
 
   static async resolveVersion(version) {
     if (version === 'latest') {
-      const body = await fetch('https://api.github.com/repos/Moddable-OpenSource/moddable-xst/releases', { headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN } })
+      const headers = process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {};
+      const body = await fetch('https://api.github.com/repos/Moddable-OpenSource/moddable-xst/releases', { headers })
         .then((r) => r.json());
       return body.find((b) => !b.prerelease).tag_name.slice(1);
     }

--- a/src/installer.js
+++ b/src/installer.js
@@ -63,7 +63,8 @@ class EngineInstaller {
 
     const url = await installer.getDownloadURL(version);
     logger.info(`Downloading ${url}`);
-    installer.downloadPath = await fetch(url, url.includes('github.com') ? { headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN } } : {})
+    const headers = process.env.GITHUB_TOKEN && url.includes('github.com') ? { 'Authorization': `Bearer ${process.env.GITHUB_TOKEN}` } : {}
+    installer.downloadPath = await fetch(url, { headers })
       .then(async (r) => {
         if (!r.ok) {
           throw new Error(`Got ${r.status}`);


### PR DESCRIPTION
Nothing warns when the env var is missing and the API requests fail in that case. For most users unauthenticated use of the API will be fine so default to that.