### PR TITLE
Fix Bali runner

### DIFF
--- a/src/engines/bali.js
+++ b/src/engines/bali.js
@@ -57,7 +57,7 @@ class BaliInstaller extends Installer {
 
   async install() {
     const js = await this.registerAsset('balde');
-    this.binPath = await this.registerScript('bali', `"${js}" run`);
+    this.binPath = await this.registerScript('bali', `"${js}"`);
   }
 
   async test() {


### PR DESCRIPTION
Bali no longer requires the `run` command to be prefixed before the filename, hence why today's test had failed.
